### PR TITLE
Updated artifactStores snippet for cross-region

### DIFF
--- a/doc_source/actions-create-cross-region.md
+++ b/doc_source/actions-create-cross-region.md
@@ -172,7 +172,7 @@ Use the AWS CLI to add a cross\-region action to a pipeline\.
    "artifactStores":{  
       "RegionA":{  
          "encryptionKey":{  
-            "id":"ID",
+            "id":"ID-A",
             "type":"KMS"
          },
          "location":"Location1",
@@ -180,7 +180,7 @@ Use the AWS CLI to add a cross\-region action to a pipeline\.
       },
       "RegionB":{  
          "encryptionKey":{  
-            "id":"ID",
+            "id":"ID-B",
             "type":"KMS"
          },
          "location":"Location2",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Under section 'Add a Cross-Region Action to a Pipeline (CLI)' Step 3, the id of the encryption key is 'ID' for both regions which appears to be the same KMS key which is not the case. For different AWS regions, you need to create different KMS keys for the respective regions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
