### PR TITLE
Fix missing RoleArn option in the put-targets command

### DIFF
--- a/doc_source/create-cwe-ecr-source-cli.md
+++ b/doc_source/create-cwe-ecr-source-cli.md
@@ -77,5 +77,5 @@ The put\-rule command above can use either the `aws.ecr` or `ecr.amazonaws.com` 
    The following sample command specifies that for the rule called `MyECRRepoRule`, the target `Id` is composed of the number one, indicating that in a list of targets for the rule, this is target 1\. The sample command also specifies an example `ARN` for the pipeline\. The pipeline starts when something changes in the repository\.
 
    ```
-   aws events put-targets --rule MyECRRepoRule --targets Id=1,Arn=arn:aws:codepipeline:us-west-2:80398EXAMPLE:TestPipeline
+   aws events put-targets --rule MyECRRepoRule --targets Id=1,Arn=arn:aws:codepipeline:us-west-2:80398EXAMPLE:TestPipeline,RoleArn=arn:aws:iam::80398EXAMPLE:role/Role-for-MyRule
    ```


### PR DESCRIPTION
The PutTargets API requires to add `RoleArn` option. Here is the error what I seen when operating the command as mentioned in the document:

```bash
$ aws events put-targets --region ap-northeast-1 --rule MyECRRepoRule --targets Id=1,Arn=arn:aws:codepipeline:ap-northeast-1:111111111111:MyPipeline

An error occurred (ValidationException) when calling the PutTargets operation: RoleArn is required for target arn:aws:codepipeline:ap-northeast-1:111111111111:MyPipeline.
```

The option has been mentioned in the CloudFormation template [1] but CLI doesn't.

Reference:
- [1] Create a CloudWatch Events Rule for an Amazon ECR Source (AWS CloudFormation Template)  - https://docs.aws.amazon.com/codepipeline/latest/userguide/create-cwe-ecr-source-cfn.html
- [2] https://docs.aws.amazon.com/cli/latest/reference/events/put-targets.html

**Here are commands I used to create the CloudWatch Event rule correctly:**
[CLI version]
```bash
$ aws --version
aws-cli/1.16.205 Python/2.7.14 Linux/4.14.67-66.56.amzn1.x86_64 botocore/1.12.195
```

```bash
$ aws iam create-role --role-name Role-for-MyRule --assume-role-policy-document file://cwe.json --region ap-northeast-1
{
    "Role": {
        "AssumeRolePolicyDocument": {
            "Version": "2012-10-17",
            "Statement": [
                {
                    "Action": "sts:AssumeRole",
                    "Effect": "Allow",
                    "Principal": {
                        "Service": "events.amazonaws.com"
                    }
                }
            ]
        },
        "RoleId": "AROATF5ENBTIPRQJPZCZJ",
        "CreateDate": "2019-09-07T08:58:05Z",
        "RoleName": "Role-for-MyRule",
        "Path": "/",
        "Arn": "arn:aws:iam::111111111111:role/Role-for-MyRule"
    }
}

$ aws iam put-role-policy --role-name Role-for-MyRule --policy-name CodePipeline-Permissions-Policy-For-CWE --policy-document file://permission.json --region ap-northeast-1

$ cat permission.json | jq
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "codepipeline:StartPipelineExecution"
      ],
      "Resource": [
        "arn:aws:codepipeline:ap-northeast-1:111111111111:MyECRRepo"
      ]
    }
  ]
}


$ aws events put-rule --region ap-northeast-1 --name "MyECRRepoRule" --event-pattern "{\"source\":[\"aws.ecr\"],\"detail\":{\"eventName\":[\"PutImage\"],\"requestParameters\":{\"repositoryName\":[\"MyECRRepo\"],\"imageTag\":[\"latest\"]}}}"
{
    "RuleArn": "arn:aws:events:ap-northeast-1:111111111111:rule/MyECRRepoRule"
}

$ aws events put-targets --region ap-northeast-1 --rule MyECRRepoRule --targets Id=1,Arn=arn:aws:codepipeline:ap-northeast-1:111111111111:MyECRRepo,RoleArn=arn:aws:iam::80398EXAMPLE:role/Role-for-MyRule
{
    "FailedEntries": [],
    "FailedEntryCount": 0
}
```
----

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
