### PR TITLE
Build image requires selecting at least one runtime version

### DIFF
--- a/doc_source/tutorials-serverlessrepo-auto-publish.md
+++ b/doc_source/tutorials-serverlessrepo-auto-publish.md
@@ -21,6 +21,9 @@ Create a `buildspec.yml` file with the following contents, and add it to your se
 ```
 version: 0.2
 phases:
+  install:
+    runtime-versions:
+        python: 3.8
   build:
     commands:
       - pip install --upgrade pip


### PR DESCRIPTION
The build phase won't get started unless we specify a runtime.

*Issue #, if available:*

*Description of changes:*
Runtime added to the installation phase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
