### PR TITLE
fix(cfn): cfn template limit with a quick work around

### DIFF
--- a/doc_source/action-reference-CloudFormation.md
+++ b/doc_source/action-reference-CloudFormation.md
@@ -80,6 +80,8 @@ This property is required for the following action modes:
 + CHANGE\_SET\_REPLACE
 For all other action modes, this property is ignored\.
 
+Note that AWS CloudFormation template file containing the template body has a minimum length of 1 byte and a maximum length of 51,200 bytes. Please refer to [AWS CloudFormation Limits](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html) for more information.
+
 **OutputFileName**  
 Required: No  
 Use `OutputFileName` to specify an output file name, such as `CreateStackOutput.json`, that CodePipeline adds to the pipeline output artifact for this action\. The JSON file contains the contents of the `Outputs` section from the AWS CloudFormation stack\.  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I believe codepipeline is calling the createstack api under the hood and pass the whole template as a string. So there is a limitation for the size of the template. So currently, this is a limitation to use cloudformation and codepipeline. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
