### PR TITLE
Remove line indicating no x-account CodeBuild

### DIFF
--- a/doc_source/pipelines-create-cross-account.md
+++ b/doc_source/pipelines-create-cross-account.md
@@ -11,7 +11,6 @@ The artifact was produced by a previous action in the same account as the action
 In other words, you cannot pass an artifact from one account to another if neither account is the pipeline account\.
 Cross\-account actions are not supported for the following action types:  
 Jenkins build actions
-CodeBuild build or test actions
 
 For this example, you must create an AWS Key Management Service \(AWS KMS\) key to use, add the key to the pipeline, and set up account policies and roles to enable cross\-account access\. For an AWS KMS key, you can use the key ID, the key ARN, or the alias ARN\. 
 


### PR DESCRIPTION
I was able to create a pipeline that invokes a CodeBuild project in another account.  I was able to do this via an action role that has a trust relationship with the pipeline account.  The line being removed in this pr indicates that this would not be possible and thus could dissuade users from trying this setup.

Let me know if you have any questions!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
