### PR TITLE
context.invokeid does not exist

### DIFF
--- a/doc_source/actions-invoke-lambda-function.md
+++ b/doc_source/actions-invoke-lambda-function.md
@@ -163,7 +163,7 @@ The event object, under the CodePipeline\.job key, contains the [job details](ht
                failureDetails: {
                    message: JSON.stringify(message),
                    type: 'JobFailed',
-                   externalExecutionId: context.invokeid
+                   externalExecutionId: context.awsRequestId
                }
            };
            codepipeline.putJobFailureResult(params, function(err, data) {


### PR DESCRIPTION
There is no `invokeid` field in the the `context` created by a CodePipeline trigger.  The closest thing I can find is the `awsRequestId` so I've substituted it here.  I initially thought `job.id` would be better but that's already part of the error response.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
