### PR TITLE
Add note about CodeDeployToECS-incompatible ZIP files

### DIFF
--- a/doc_source/troubleshooting.md
+++ b/doc_source/troubleshooting.md
@@ -137,11 +137,11 @@ To add permissions to your CodeBuild service role policy, you create a customer\
 
 **Problem:** 
 
-The maximum artifact ZIP size in the CodePipeline deploy action to ECS through CodeDeploy \(the `CodeDeployToECS` action\) is 3 MB\. The following error message is returned when artifact sizes exceed 3 MB: 
+The maximum artifact ZIP size in the CodePipeline deploy action to ECS through CodeDeploy \(the `CodeDeployToECS` action\) is 3 MB\. Also, ZIP files that use input streams together with the store (uncompressed) archiving method are not supported. The following error message is returned when artifact sizes exceed 3 MB, or if the ZIP file uses stored (uncompressed) input streams: 
 
 Exception while trying to read the task definition artifact file from: <source artifact name>
 
-**Possible fixes:** Create an artifact with a compressed size less than 3 MB\.
+**Possible fixes:** Create an artifact with a compressed size less than 3 MB\. Also, verify that the ZIP file does not use the combination of input streams and the store (uncompressed) archiving method\.
 
 ## Need help with a different issue?<a name="troubleshooting-other"></a>
 


### PR DESCRIPTION
Reviewer notes:
* It's probably a good idea to run this by the CodePipeline/CD/ECS team.
* Rather than documenting this behaviour, it would be greatly preferred if it was fixed in CodePipeline instead.
* In addition to documenting this behaviour, it would be good to improve the error messages so that they contain clearer and more actionable information.
* More details on the issue can be found in https://github.com/aws/containers-roadmap/issues/1112

```
ZIP files that use the combination of streaming input and the store
(uncompressed) archiving method, will make the CodeDeployToECS action
return an error:

  Exception while trying to read the task definition artifact file from: <source artifact name>

This error is identical to the one prompted by exceeding the maximum
compressed artifact size limit of 3 MB.

ZIP files that use streaming input will put file entry metadata after
writing the file body (compressed or not, depending on method). When
using the store archiving method, there may be ambiguity around whether
the complete body is present. The deflate method does not have this
problem, since this information is encoded into the deflate format. Some
ZIP implementations, notably java.util.zip, do not support this
combination, and will throw an exception. For example:

  java.util.zip.ZipException: only DEFLATED entries can have EXT descriptor
    at java.base/java.util.zip.ZipInputStream.readLOC(ZipInputStream.java:311)
    at java.base/java.util.zip.ZipInputStream.getNextEntry(ZipInputStream.java:123)

Related links:
  https://github.com/aws/containers-roadmap/issues/1112
  https://bugs.openjdk.java.net/browse/JDK-8143613
  https://stackoverflow.com/questions/47208272/android-zipinputstream-only-deflated-entries-can-have-ext-descriptor
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.