### PR TITLE
Update ecs-cd-pipeline.md

### DIFF
--- a/doc_source/ecs-cd-pipeline.md
+++ b/doc_source/ecs-cd-pipeline.md
@@ -232,7 +232,7 @@ Now that the pipeline has been created, it attempts to run through the different
 
 ## Step 3: Add Amazon ECR Permissions to the CodeBuild Role<a name="code-build-perms"></a>
 
-The CodePipeline wizard created an IAM role for the CodeBuild build project, called **code\-build\-*build\-project\-name*\-service\-role**\. For this tutorial, the name is **code\-build\-hello\-world\-service\-role**\. Because the `buildspec.yml` file makes calls to Amazon ECR API operations, the role must have a policy that allows permissions to make these Amazon ECR calls\. The following procedure helps you attach the proper permissions to the role\.
+The CodePipeline wizard created an IAM role for the CodeBuild build project, called **codebuild\-*build\-project\-name*\-service\-role**\. For this tutorial, the name is **codebuild\-hello\-world\-service\-role**\. Because the `buildspec.yml` file makes calls to Amazon ECR API operations, the role must have a policy that allows permissions to make these Amazon ECR calls\. The following procedure helps you attach the proper permissions to the role\.
 
 **To add Amazon ECR permissions to the CodeBuild role**
 


### PR DESCRIPTION
Tutorial says the role created for the CodeBuild project is "code-build-..." and then later "codebuild-...". It should be "codebuild" in all cases.

*Issue #, if available:* Incorrect name displayed for the CodeBuild project IAM role created.

*Description of changes:* Tutorial gives two different names for the IAM role created by the Code Build project. This PR seeks to remove the incorrect name given.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
