### PR TITLE
document that CF action RoleArn needs access to the template, but CF service role doesn't

### DIFF
--- a/doc_source/action-reference-CloudFormation.md
+++ b/doc_source/action-reference-CloudFormation.md
@@ -66,6 +66,9 @@ This property is required for the following action modes:
 + DELETE\_ONLY
 + CHANGE\_SET\_REPLACE
 
+**Note**  
+CloudFormation is given an S3 signed URL to the template, and therefore this `RoleArn` does not need permission to access the artifact bucket. However, the action `RoleArn` _does_ need permission to access the artifact bucket, in order to generate the signed URL.
+
 **TemplatePath**  
 Required: Conditional  
 `TemplatePath` represents the AWS CloudFormation template file\. You include the file in an input artifact to this action\. The file name follows this format:  


### PR DESCRIPTION
*Description of changes:*

It appears (although I'm partly guessing and going off https://github.com/aws/aws-cdk/issues/12985#issuecomment-799322855, and an error I got when the action deploy role didn't have s3 permissions) that the CloudFormation action generates a signed URL to the template, and passes that signed URL to CloudFormation.

This means the CloudFormation service role does not need permission to access the artifact bucket, because the signed URL is publicly accessible.

Also it means the action `RoleArn` (if configured), _does_ need access to the artifact bucket, to generate the signed URL.

Would be great to get confirmation that this is how it works and the docs updated to make this clear.
