### PR TITLE
add note that the CloudFormation `RoleArn` must be in same account as action `RoleArn`

### DIFF
--- a/doc_source/action-reference-CloudFormation.md
+++ b/doc_source/action-reference-CloudFormation.md
@@ -66,6 +66,9 @@ This property is required for the following action modes:
 + DELETE\_ONLY
 + CHANGE\_SET\_REPLACE
 
+**Note**  
+This role must be in the same account as the role that the action is running as, configured in the action declaration `RoleArn`.
+
 **TemplatePath**  
 Required: Conditional  
 `TemplatePath` represents the AWS CloudFormation template file\. You include the file in an input artifact to this action\. The file name follows this format:  

--- a/doc_source/action-reference-CloudFormation.md
+++ b/doc_source/action-reference-CloudFormation.md
@@ -70,7 +70,7 @@ This property is required for the following action modes:
 This role must be in the same account as the role that the action is running as, configured in the action declaration `RoleArn`\.
 
 **Note**  
-CloudFormation is given an S3 signed URL to the template, and therefore this `RoleArn` does not need permission to access the artifact bucket. However, the action `RoleArn` _does_ need permission to access the artifact bucket, in order to generate the signed URL.
+CloudFormation is given an S3 signed URL to the template, and therefore this `RoleArn` does not need permission to access the artifact bucket\. However, the action `RoleArn` _does_ need permission to access the artifact bucket, in order to generate the signed URL\.
 
 **TemplatePath**  
 Required: Conditional  


### PR DESCRIPTION
*Description of changes:*

I tried to configure a CloudFormation action in a CodePipeline to use the deploy role in account A and use a role in account B as the CloudFormation execution role, giving account A permission to `iam:PassRole` the execution role in Account B, but I got the following error:

```
Cross-account pass role is not allowed.
```

See https://github.com/awsdocs/iam-user-guide/pull/228#issuecomment-817987408
