### PR TITLE
Node 10.x option no longer available

### DIFF
--- a/doc_source/actions-invoke-lambda-function.md
+++ b/doc_source/actions-invoke-lambda-function.md
@@ -116,7 +116,7 @@ These are the minimum permissions required for a Lambda function to interoperate
 **Note**  
 If you see a **Welcome** page instead of the **Lambda** page, choose **Get Started Now**\.
 
-1. On the **Create function** page, choose **Author from scratch**\. In **Function name**, enter a name for your Lambda function \(for example, **MyLambdaFunctionForAWSCodePipeline**\)\. In **Runtime**, choose **Node\.js 10\.x**\.
+1. On the **Create function** page, choose **Author from scratch**\. In **Function name**, enter a name for your Lambda function \(for example, **MyLambdaFunctionForAWSCodePipeline**\)\. In **Runtime**, choose **Node\.js 14\.x**\.
 
    
 


### PR DESCRIPTION
Instruction below is old:  
On the **Create function** page, choose **Author from scratch**\. In **Function name**, enter a name for your Lambda function \(for example, **MyLambdaFunctionForAWSCodePipeline**\)\. In **Runtime**, choose **Node\.js 10\.x**\.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
