### PR TITLE
Updated the correct format of accounts.txt file

### DIFF
--- a/doc_source/tutorials-stackset-deployment.md
+++ b/doc_source/tutorials-stackset-deployment.md
@@ -82,7 +82,7 @@ Make sure to ZIP the source files before you upload to your S3 source bucket, ev
 
    ```
    [
-       "111111222222,333333444444"
+       "111111222222","333333444444"
    ]
    ```
 


### PR DESCRIPTION
*Issue #, if available:* With the previous format, it was throwing an error as "DeploymentTargets contains values that are neither accounts nor organizational units. Please correct them and try again. Values: 111111222222,333333444444

*Description of changes:* Replace "111111222222,333333444444" with "111111222222","333333444444"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
